### PR TITLE
Added "setCustomBeforePreviousTarget" and "setCustomBeforeNextTarget"

### DIFF
--- a/IQKeyBoardManager/IQKeyboardManager.m
+++ b/IQKeyBoardManager/IQKeyboardManager.m
@@ -1459,6 +1459,11 @@ void _IQShowLog(NSString *logString);
         //  Retaining textFieldView
         UIView *textFieldRetain = _textFieldView;
         
+        if (textFieldRetain.beforePreviousInvocation)
+        {
+            [textFieldRetain.beforePreviousInvocation invoke];
+        }
+        
         BOOL isAcceptAsFirstResponder = [nextTextField becomeFirstResponder];
         
         //  If it refuses then becoming previous textFieldView as first responder again.    (Bug ID: #96)
@@ -1494,6 +1499,11 @@ void _IQShowLog(NSString *logString);
         
         //  Retaining textFieldView
         UIView *textFieldRetain = _textFieldView;
+        
+        if (textFieldRetain.beforeNextInvocation)
+        {
+            [textFieldRetain.beforeNextInvocation invoke];
+        }
         
         BOOL isAcceptAsFirstResponder = [nextTextField becomeFirstResponder];
         

--- a/IQKeyBoardManager/IQToolbar/IQUIView+IQKeyboardToolbar.h
+++ b/IQKeyBoardManager/IQToolbar/IQUIView+IQKeyboardToolbar.h
@@ -52,7 +52,23 @@
  @param target Target object.
  @param action Target Selector.
  */
+-(void)setCustomBeforePreviousTarget:(nullable id)target action:(nullable SEL)action;
+
+/**
+ Additional target & action to do get callback action. Note that setting custom `previous` selector doesn't affect native `previous` functionality, this is just used to notifiy user to do additional work according to need.
+ 
+ @param target Target object.
+ @param action Target Selector.
+ */
 -(void)setCustomPreviousTarget:(nullable id)target action:(nullable SEL)action;
+
+/**
+ Additional target & action to do get callback action. Note that setting custom `previous` selector doesn't affect native `previous` functionality, this is just used to notifiy user to do additional work according to need.
+ 
+ @param target Target object.
+ @param action Target Selector.
+ */
+-(void)setCustomBeforeNextTarget:(nullable id)target action:(nullable SEL)action;
 
 /**
  Additional target & action to do get callback action. Note that setting custom `next` selector doesn't affect native `next` functionality, this is just used to notifiy user to do additional work according to need.
@@ -71,9 +87,19 @@
 -(void)setCustomDoneTarget:(nullable id)target action:(nullable SEL)action;
 
 /**
+ Customized Invocation to be called BEFORE previous arrow action. previousInvocation is internally created using setCustomPreviousTarget: method.
+ */
+@property (nullable, strong, nonatomic) NSInvocation *beforePreviousInvocation;
+
+/**
  Customized Invocation to be called on previous arrow action. previousInvocation is internally created using setCustomPreviousTarget: method.
  */
 @property (nullable, strong, nonatomic) NSInvocation *previousInvocation;
+
+/**
+ Customized Invocation to be called BEFORE next arrow action. previousInvocation is internally created using setCustomPreviousTarget: method.
+ */
+@property (nullable, strong, nonatomic) NSInvocation *beforeNextInvocation;
 
 /**
  Customized Invocation to be called on next arrow action. nextInvocation is internally created using setCustomNextTarget: method.

--- a/IQKeyBoardManager/IQToolbar/IQUIView+IQKeyboardToolbar.m
+++ b/IQKeyBoardManager/IQToolbar/IQUIView+IQKeyboardToolbar.m
@@ -53,6 +53,16 @@
     return [shouldHideTitle boolValue];
 }
 
+-(void)setCustomBeforePreviousTarget:(nullable id)target action:(nullable SEL)action
+{
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[target methodSignatureForSelector:action]];
+    invocation.target = target;
+    invocation.selector = action;
+    UIView *selfObject = self;
+    [invocation setArgument:&selfObject atIndex:2];
+    self.beforePreviousInvocation = invocation;
+}
+
 -(void)setCustomPreviousTarget:(id)target action:(SEL)action
 {
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[target methodSignatureForSelector:action]];
@@ -61,6 +71,16 @@
     UIView *selfObject = self;
     [invocation setArgument:&selfObject atIndex:2];
     self.previousInvocation = invocation;
+}
+
+-(void)setCustomBeforeNextTarget:(nullable id)target action:(nullable SEL)action
+{
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[target methodSignatureForSelector:action]];
+    invocation.target = target;
+    invocation.selector = action;
+    UIView *selfObject = self;
+    [invocation setArgument:&selfObject atIndex:2];
+    self.beforeNextInvocation = invocation;
 }
 
 -(void)setCustomNextTarget:(id)target action:(SEL)action
@@ -83,9 +103,19 @@
     self.doneInvocation = invocation;
 }
 
+-(void)setBeforePreviousInvocation:(NSInvocation *)beforePreviousInvocation
+{
+    objc_setAssociatedObject(self, @selector(beforePreviousInvocation), beforePreviousInvocation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 -(void)setPreviousInvocation:(NSInvocation *)previousInvocation
 {
     objc_setAssociatedObject(self, @selector(previousInvocation), previousInvocation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+-(void)setBeforeNextInvocation:(NSInvocation *)beforeNextInvocation
+{
+    objc_setAssociatedObject(self, @selector(beforeNextInvocation), beforeNextInvocation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 -(void)setNextInvocation:(NSInvocation *)nextInvocation
@@ -98,9 +128,18 @@
     objc_setAssociatedObject(self, @selector(doneInvocation), doneInvocation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+-(NSInvocation *)beforePreviousInvocation
+{
+    return objc_getAssociatedObject(self, @selector(beforePreviousInvocation));
+}
 -(NSInvocation *)previousInvocation
 {
     return objc_getAssociatedObject(self, @selector(previousInvocation));
+}
+
+-(NSInvocation *)beforeNextInvocation
+{
+    return objc_getAssociatedObject(self, @selector(beforeNextInvocation));
 }
 
 -(NSInvocation *)nextInvocation


### PR DESCRIPTION
- Added "setCustomBeforePreviousTarget" and "setCustomBeforeNextTarget" methods for supporting the execution of actions on tapping next/previous navigation arrow buttons but BEFORE the UI changes to next/previous field - since the existing methods "setCustomPreviousTarget" and "setCustomNextTarget" only notify the target action after the UI already add changed to the next/previous field.
